### PR TITLE
Add person fullname to alt and title of avatars

### DIFF
--- a/src/components/article/AuthorAvatar.tsx
+++ b/src/components/article/AuthorAvatar.tsx
@@ -4,14 +4,15 @@ import type { FixedObject } from "../../v2/core/models"
 
 interface AuthorAvatarProps {
   avatar: FixedObject
+  avatarTitle?: string
 }
 
-export default function ({ avatar }: AuthorAvatarProps) {
+export default function ({ avatar, avatarTitle }: AuthorAvatarProps) {
   return (
     <Image
       className="center circle shadow1 author-avatar"
-      alt={avatar.originalName}
-      title={avatar.originalName}
+      alt={avatarTitle || avatar.originalName}
+      title={avatarTitle || avatar.originalName}
       fixed={avatar}
       style={{
         borderRadius: "50%",

--- a/src/v2/components/Reviewers.tsx
+++ b/src/v2/components/Reviewers.tsx
@@ -51,21 +51,30 @@ export const Reviewers = ({
     <Container className="center components-reviewers">
       <Link to="/authors/">
         <div className="reviewers-avatar-container col">
-          <AuthorAvatar avatar={tech.avatar.small} />
+          <AuthorAvatar
+            avatar={tech.avatar.small}
+            avatarTitle={tech.full_name}
+          />
           <S>{techLabel}</S>
         </div>
       </Link>
 
       <Link to="/authors/">
         <div className="reviewers-avatar-container col">
-          <AuthorAvatar avatar={author.avatar.medium} />
+          <AuthorAvatar
+            avatar={author.avatar.medium}
+            avatarTitle={author.full_name}
+          />
           <S>{authorLabel}</S>
         </div>
       </Link>
 
       <Link to="/authors/">
         <div className="reviewers-avatar-container col">
-          <AuthorAvatar avatar={ling.avatar.small} />
+          <AuthorAvatar
+            avatar={ling.avatar.small}
+            avatarTitle={ling.full_name}
+          />
           <S>{lingLabel}</S>
         </div>
       </Link>

--- a/src/v2/features/article/containers/ArticleFooter.tsx
+++ b/src/v2/features/article/containers/ArticleFooter.tsx
@@ -180,7 +180,10 @@ const ArticleFooter = () => {
       <div className="article-footer-author-section row">
         <Link to={layout.routes.authors.to}>
           <div className="clickable row">
-            <AuthorAvatar avatar={article.author.avatar.small} />
+            <AuthorAvatar
+              avatar={article.author.avatar.small}
+              avatarTitle={article.author.full_name}
+            />
             <div className="author-personality col">
               <M className="cap" bold>
                 {article.author.full_name}

--- a/src/v2/features/articles/containers/ArticlesGrid.tsx
+++ b/src/v2/features/articles/containers/ArticlesGrid.tsx
@@ -142,9 +142,7 @@ const ArticlesGrid = () => {
             </Tags>
             <Link to={path}>
               <XL>
-                <span title={layoutT[seniority]}>
-                  {Seniority[seniority]}
-                </span>{" "}
+                <span title={layoutT[seniority]}>{Seniority[seniority]}</span>
                 {title}
               </XL>
             </Link>
@@ -152,7 +150,10 @@ const ArticlesGrid = () => {
 
             <div className="tile-details row">
               <Link to={routes.authors.to}>
-                <AuthorAvatar avatar={author.avatar.small} />
+                <AuthorAvatar
+                  avatar={author.avatar.small}
+                  avatarTitle={author.full_name}
+                />
               </Link>
               <ReadTime time={read_time} />
               {is_new && <Badge color={theme.green}>{newText}</Badge>}

--- a/src/v2/features/articles/containers/FiltersForm.tsx
+++ b/src/v2/features/articles/containers/FiltersForm.tsx
@@ -167,7 +167,11 @@ const FiltersForm = ({ trigger }: FiltersFormProps) => {
                 {articlesPageT.all} ({authors.length})
               </span>
               {authors.slice(0, AUTHORS_DISPLAY_LIMIT).map(author => (
-                <AuthorAvatar key={author.id} avatar={author.avatar.tiny} />
+                <AuthorAvatar
+                  key={author.id}
+                  avatar={author.avatar.tiny}
+                  avatarTitle={author.full_name}
+                />
               ))}
               <span>... +{authors.length - AUTHORS_DISPLAY_LIMIT}</span>
             </Badge>
@@ -183,7 +187,10 @@ const FiltersForm = ({ trigger }: FiltersFormProps) => {
                     filters.authors[author.id] ? " active" : ""
                   }`}
                 >
-                  <AuthorAvatar avatar={author.avatar.small} />
+                  <AuthorAvatar
+                    avatar={author.avatar.small}
+                    avatarTitle={author.full_name}
+                  />
                 </div>
               ))}
             </section>

--- a/src/v2/features/authors/AuthorsView.tsx
+++ b/src/v2/features/authors/AuthorsView.tsx
@@ -34,7 +34,12 @@ const AuthorsView = () => {
               bio={author.bio}
               role={author.role}
               fullName={author.full_name}
-              avatar={<AuthorAvatar avatar={author.avatar} />}
+              avatar={
+                <AuthorAvatar
+                  avatar={author.avatar}
+                  avatarTitle={author.full_name}
+                />
+              }
               footer={
                 <>
                   {author.github_url && (


### PR DESCRIPTION
Issue: Hovering over the avatar now shows the file name. Better to show the name of the person.
![issue](https://github.com/polubis/WebBlog/assets/103119318/8c253bd6-eb28-4aa5-93c8-3e9adcac3636)

--->

![solved](https://github.com/polubis/WebBlog/assets/103119318/dd00fdd4-6fee-4fd1-9a66-96f0ee5d9023)
